### PR TITLE
Implement Warren Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A React web app built to simplify picking 5-a-side football teams. The app ensur
 - Generate multiple team options for voting
 - Randomly generated team names, with local options for London and Hampshire (more regions can be added)
 - Export saved teams as an image to share with friends
+- Optional "Warren Mode" adds a chance for messages to be cheeky or lovely
 
 ### Local Development
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A React web app built to simplify picking 5-a-side football teams. The app ensur
 - Generate multiple team options for voting
 - Randomly generated team names, with local options for London and Hampshire (more regions can be added)
 - Export saved teams as an image to share with friends
-- Optional "Warren Mode" adds a chance for messages to be cheeky or lovely
+- Optional "Warren Mode" spices up warnings and summaries (80% lovely, 20% a bit nasty)
 
 ### Local Development
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,16 +67,15 @@ const FootballTeamPicker = () => {
         if (!warrenMode) return msg;
         const nasty = [
             ' Sort it out, pal!',
-            ' Did your brain take a day off?',
-            ' Honestly, that\'s pathetic.'
+            ' Honestly, that\'s pathetic.',
+            'Use your eyes, mate!',
+            'That\'s a fucking disgrace!',
         ];
         const lovely = [
             ' You\'re doing great!',
             ' Lovely stuff!',
             ' Keep it up, legend!',
-            ' Sparkling work!',
-            ' You absolute star!',
-            " That's brilliant!"
+            ' Fucking great work, mate!',
         ];
         if (Math.random() < 0.2) {
             return msg + ' ' + nasty[Math.floor(Math.random() * nasty.length)];
@@ -599,7 +598,7 @@ const FootballTeamPicker = () => {
                             Tip: Click one player, then another to swap their positions on the pitch!
                         </span>
                     </p>
-                    
+
                 </div>
 
                 <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ const FootballTeamPicker = () => {
         return localStorage.getItem('selectedLocation') || 'Generic'; // Load from localStorage or default to Hampshire
     });
     const [places, setPlaces] = useState<string[]>(teamPlaces.Generic.places); // Default to Hampshire places
-    const [notification, setNotification] = useState<string | null>(null); // State for notification message
+    const [notifications, setNotifications] = useState<{ id: number; message: string }[]>([]);
     const [showNoGoalkeeperInfo, setShowNoGoalkeeperInfo] = useState(false); // State to track if the info box should be shown
     const [isLoadingLocation, setIsLoadingLocation] = useState(false); // New state for loading animation
     const [selectedPlayer, setSelectedPlayer] = useState<{
@@ -73,12 +73,24 @@ const FootballTeamPicker = () => {
         const lovely = [
             ' You\'re doing great!',
             ' Lovely stuff!',
-            ' Keep it up, legend!'
+            ' Keep it up, legend!',
+            ' Sparkling work!',
+            ' You absolute star!',
+            " That's brilliant!"
         ];
-        if (Math.random() < 0.1) {
+        if (Math.random() < 0.2) {
             return msg + ' ' + nasty[Math.floor(Math.random() * nasty.length)];
         }
         return msg + ' ' + lovely[Math.floor(Math.random() * lovely.length)];
+    };
+
+    const addNotification = (msg: string) => {
+        const id = Date.now() + Math.random();
+        setNotifications(n => [...n, { id, message: msg }]);
+    };
+
+    const removeNotification = (id: number) => {
+        setNotifications(n => n.filter(note => note.id !== id));
     };
 
     const handleLocationChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -91,9 +103,9 @@ const FootballTeamPicker = () => {
         setPlaces(places);
         setIsLoadingLocation(false); // Stop loading animation
         if (location === 'Generic') {
-            setNotification(applyWarrenTone("Sorry, we don't have any regional data for your location. Defaulting to Generic"));
+            addNotification(applyWarrenTone("Sorry, we don't have any regional data for your location. Defaulting to Generic"));
         } else {
-            setNotification(applyWarrenTone(`Location found: ${location}`)); // Show notification
+            addNotification(applyWarrenTone(`Location found: ${location}`)); // Show notification
         }
     };
 
@@ -560,9 +572,13 @@ const FootballTeamPicker = () => {
                 onWarrenModeChange={setWarrenMode}
             />
             <div className="flex-grow p-4 sm:p-6">
-                {/* Notification */}
-                {notification && (
-                    <Notification message={notification} onClose={() => setNotification(null)} />
+                {/* Notifications */}
+                {notifications.length > 0 && (
+                    <div className="fixed bottom-24 right-4 flex flex-col items-end space-y-2 z-50">
+                        {notifications.map(n => (
+                            <Notification key={n.id} message={n.message} onClose={() => removeNotification(n.id)} />
+                        ))}
+                    </div>
                 )}
 
                 {/* Title Section */}
@@ -643,7 +659,7 @@ Billy #g"
                                             setTeamSetups([]);
                                             setErrorMessage('');
                                             setPlayerNumbers({});
-                                            setNotification(applyWarrenTone(`All teams cleared`));
+                                            addNotification(applyWarrenTone(`All teams cleared`));
                                         }}
                                         className="bg-green-900 text-white py-2 px-4 rounded font-bold shadow-md transition border border-white hover:bg-green-800"
                                     >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ const FootballTeamPicker = () => {
     const [aiModel, setAIModel] = useState(() => localStorage.getItem('aiModel') || 'gemini-2.0-flash');
     const [aiSummaries, setAISummaries] = useState<{ [setupIndex: number]: string }>({});
     const [geminiKeyError, setGeminiKeyError] = useState<string | null>(null);
+    const [warrenMode, setWarrenMode] = useState(() => localStorage.getItem('warrenMode') === 'true');
     const aiInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
@@ -49,6 +50,10 @@ const FootballTeamPicker = () => {
     }, [selectedLocation]);
 
     useEffect(() => {
+        localStorage.setItem('warrenMode', String(warrenMode));
+    }, [warrenMode]);
+
+    useEffect(() => {
         // Update places based on selected location
         setPlaces((teamPlaces as any)[selectedLocation]?.places || teamPlaces.Generic.places);
     }, [selectedLocation]);
@@ -57,6 +62,24 @@ const FootballTeamPicker = () => {
     useEffect(() => {
         setAISummaries({});
     }, [teamSetups]);
+
+    const applyWarrenTone = (msg: string) => {
+        if (!warrenMode) return msg;
+        const nasty = [
+            ' Sort it out, pal!',
+            ' Did your brain take a day off?',
+            ' Honestly, that\'s pathetic.'
+        ];
+        const lovely = [
+            ' You\'re doing great!',
+            ' Lovely stuff!',
+            ' Keep it up, legend!'
+        ];
+        if (Math.random() < 0.1) {
+            return msg + ' ' + nasty[Math.floor(Math.random() * nasty.length)];
+        }
+        return msg + ' ' + lovely[Math.floor(Math.random() * lovely.length)];
+    };
 
     const handleLocationChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         setSelectedLocation(event.target.value);
@@ -68,22 +91,22 @@ const FootballTeamPicker = () => {
         setPlaces(places);
         setIsLoadingLocation(false); // Stop loading animation
         if (location === 'Generic') {
-            setNotification("Sorry, we don't have any regional data for your location.Defaulting to Generic");
+            setNotification(applyWarrenTone("Sorry, we don't have any regional data for your location. Defaulting to Generic"));
         } else {
-            setNotification(`Location found: ${location}`); // Show notification
+            setNotification(applyWarrenTone(`Location found: ${location}`)); // Show notification
         }
     };
 
     const generateTeams = () => {
         if (!playersText.trim()) {
-            setErrorMessage('Please enter player names');
+            setErrorMessage(applyWarrenTone('Please enter player names'));
             return;
         }
 
         const playerLines = playersText.split('\n').filter(line => line.trim().length > 0);
 
         if (playerLines.length < 10) {
-            setErrorMessage('You need at least 10 players for two 5-a-side teams');
+            setErrorMessage(applyWarrenTone('You need at least 10 players for two 5-a-side teams'));
             return;
         }
 
@@ -114,11 +137,11 @@ const FootballTeamPicker = () => {
 
         const numTeams = Math.floor(2);
         if (goalkeepers.length < numTeams) {
-            setErrorMessage(`You need at least ${numTeams} goalkeepers`);
+            setErrorMessage(applyWarrenTone(`You need at least ${numTeams} goalkeepers`));
         }
 
         if (players.length > 16) {
-            setErrorMessage('You can only have a maximum of 16 players');
+            setErrorMessage(applyWarrenTone('You can only have a maximum of 16 players'));
             return;
         }
 
@@ -511,9 +534,9 @@ const FootballTeamPicker = () => {
             });
             const data = await res.json();
             const summary = data.candidates?.[0]?.content?.parts?.[0]?.text || 'No summary generated.';
-            setAISummaries(prev => ({ ...prev, [setupIndex]: summary }));
+            setAISummaries(prev => ({ ...prev, [setupIndex]: applyWarrenTone(summary) }));
         } catch (e) {
-            setAISummaries(prev => ({ ...prev, [setupIndex]: 'Error generating summary.' }));
+            setAISummaries(prev => ({ ...prev, [setupIndex]: applyWarrenTone('Error generating summary.') }));
         }
     };
 
@@ -533,6 +556,8 @@ const FootballTeamPicker = () => {
                 onGeminiKeySave={handleGeminiKeySave}
                 aiInputRef={aiInputRef}
                 geminiKeyError={geminiKeyError}
+                warrenMode={warrenMode}
+                onWarrenModeChange={setWarrenMode}
             />
             <div className="flex-grow p-4 sm:p-6">
                 {/* Notification */}
@@ -618,7 +643,7 @@ Billy #g"
                                             setTeamSetups([]);
                                             setErrorMessage('');
                                             setPlayerNumbers({});
-                                            setNotification(`All teams cleared`);
+                                            setNotification(applyWarrenTone(`All teams cleared`));
                                         }}
                                         className="bg-green-900 text-white py-2 px-4 rounded font-bold shadow-md transition border border-white hover:bg-green-800"
                                     >

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -13,6 +13,8 @@ interface HeaderBarProps {
     onGeminiKeySave: () => void;
     aiInputRef: React.RefObject<HTMLInputElement>;
     geminiKeyError: string | null;
+    warrenMode: boolean;
+    onWarrenModeChange: (value: boolean) => void;
 }
 
 const HeaderBar: React.FC<HeaderBarProps> = ({
@@ -26,6 +28,8 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     onGeminiKeySave,
     aiInputRef,
     geminiKeyError,
+    warrenMode,
+    onWarrenModeChange,
 }) => {
     const [showConfig, setShowConfig] = useState(false);
 
@@ -114,6 +118,17 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                             {geminiKeyError && (
                                 <div className="text-red-600 text-sm mt-2">{geminiKeyError}</div>
                             )}
+                        </div>
+                        <div>
+                            <label className="font-bold flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    checked={warrenMode}
+                                    onChange={(e) => onWarrenModeChange(e.target.checked)}
+                                />
+                                Warren Mode
+                            </label>
+                            <p className="text-xs mt-1">Adds spicy or lovely tone to messages.</p>
                         </div>
                     </div>
                 )}

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -12,7 +12,7 @@ const Notification: React.FC<NotificationProps> = ({ message, onClose }) => {
     }, [onClose]);
 
     return (
-        <div className="fixed bottom-24 right-4 bg-purple-600 text-white px-4 py-2 rounded shadow-lg z-50">
+        <div className="bg-purple-600 text-white px-4 py-2 rounded shadow-lg">
             {message}
         </div>
     );

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -7,12 +7,12 @@ interface NotificationProps {
 
 const Notification: React.FC<NotificationProps> = ({ message, onClose }) => {
     useEffect(() => {
-        const timer = setTimeout(onClose, 3000); // Automatically close after 3 seconds
+        const timer = setTimeout(onClose, 5000); // Automatically close after 5 seconds
         return () => clearTimeout(timer);
     }, [onClose]);
 
     return (
-        <div className="fixed top-4 right-4 bg-blue-600 text-white px-4 py-2 rounded shadow-lg z-50">
+        <div className="fixed bottom-24 right-4 bg-purple-600 text-white px-4 py-2 rounded shadow-lg z-50">
             {message}
         </div>
     );


### PR DESCRIPTION
## Summary
- add Warren Mode toggle to config menu
- randomize tone of warnings and AI summaries when Warren Mode is on
- persist Warren Mode setting in local storage
- document new feature in README

## Testing
- `npm run lint` *(fails: isWithinRadius assigned a value but never used and other existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6878f59dc1808333b706b62749b5d530