### PR TITLE
UI tweaks for AI summary and footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -670,10 +670,6 @@ Billy #g"
                                         Reset
                                     </Button>
                                 </div>
-                                <div className="text-sm font-bold text-green-200">
-                                    Teams Generated: {teamSetups.length}
-                                </div>
-
                                 {errorMessage && (
                                     <div className="mt-3 bg-red-700 border border-red-500 text-white px-4 py-2 rounded">
                                         {errorMessage}
@@ -919,17 +915,19 @@ Billy #g"
                                                 </div>
                                             </div>
                                         )}
-                                        <div className="flex justify-end mt-2">
-                                            {!aiSummaries[setupIndex] && (
-                                                <Button
-                                                    onClick={() => handleGenerateSummary(setupIndex)}
-                                                    className="bg-yellow-400 text-green-900 font-bold px-3 py-1 rounded shadow flex items-center gap-2 generate-ai-summary"
-                                                    disabled={!geminiKey || aiSummaries[setupIndex] === 'Loading...'}
-                                                >
-                                                    {aiSummaries[setupIndex] === 'Loading...' ? 'Generating...' : 'Generate AI Match Summary'}
-                                                </Button>
-                                            )}
-                                        </div>
+                                        {geminiKey && (
+                                            <div className="flex justify-end mt-2">
+                                                {!aiSummaries[setupIndex] && (
+                                                    <Button
+                                                        onClick={() => handleGenerateSummary(setupIndex)}
+                                                        className="bg-yellow-400 text-green-900 font-bold px-3 py-1 rounded shadow flex items-center gap-2 generate-ai-summary"
+                                                        disabled={aiSummaries[setupIndex] === 'Loading...'}
+                                                    >
+                                                        {aiSummaries[setupIndex] === 'Loading...' ? 'Generating...' : 'Generate AI Match Summary'}
+                                                    </Button>
+                                                )}
+                                            </div>
+                                        )}
                                         {aiSummaries[setupIndex] && (
                                             <div className="backdrop-blur bg-white/10 border border-white/20 rounded p-4 mt-2 text-white prose prose-sm max-w-none">
                                                 <ReactMarkdown>{aiSummaries[setupIndex]}</ReactMarkdown>
@@ -945,7 +943,7 @@ Billy #g"
 
             {/* Footer */}
             <Footer />
-            <FloatingFooter visible={teamSetups.length > 0} onExport={exportAllImages} />
+            <FloatingFooter visible={teamSetups.length > 0} onExport={exportAllImages} teamCount={teamSetups.length} />
         </div>
     );
 };

--- a/src/components/FloatingFooter.tsx
+++ b/src/components/FloatingFooter.tsx
@@ -4,13 +4,15 @@ import { Button } from './ui/button';
 interface FloatingFooterProps {
     visible: boolean;
     onExport: () => void;
+    teamCount: number;
 }
 
-const FloatingFooter: React.FC<FloatingFooterProps> = ({ visible, onExport }) => {
+const FloatingFooter: React.FC<FloatingFooterProps> = ({ visible, onExport, teamCount }) => {
     if (!visible) return null;
 
     return (
-        <div className="fixed bottom-0 left-0 right-0 bg-green-900 text-white py-3 flex justify-end pr-4 z-50 shadow-lg">
+        <div className="fixed bottom-0 left-0 right-0 bg-green-900 text-white py-3 flex items-center justify-end pr-4 z-50 shadow-lg">
+            <div className="flex-grow pl-4 font-bold">Teams Generated: {teamCount}</div>
             <Button
                 onClick={onExport}
                 className="bg-blue-700 text-white py-2 px-6 rounded font-bold shadow-md hover:bg-blue-800 flex items-center gap-2"


### PR DESCRIPTION
## Summary
- hide AI summary button when Gemini API key isn't saved
- remove count from create team section
- show total teams generated in floating footer

## Testing
- `npm run lint` *(fails: 25 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6878ff92dff883339bc6c20be1e168b9