### PR TITLE
Add GitHub Pages preview workflow for PRs

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,50 @@
+name: Preview PR
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build project
+      run: npm run build
+      env:
+        BASE_PATH: /pr/${{ github.event.number }}/
+
+    - name: Deploy preview
+      id: deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./dist
+        destination_dir: pr/${{ github.event.number }}
+
+    - name: Comment preview URL
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const pr = context.payload.pull_request.number;
+          const url = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr/${pr}/`;
+          github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr,
+            body: `Preview URL: ${url}`,
+          });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 export default defineConfig({
+  base: process.env.BASE_PATH || "/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure Vite to allow a custom base path
- add `pr-preview.yml` workflow to deploy PR builds to GitHub Pages and comment a preview URL

## Testing
- `npm ci`
- `npm run lint` *(fails: cannot type-check several files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68795036b4488333bfbf5138d2581ace