### PR TITLE
Update Warren mode tone in AI prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -552,8 +552,19 @@ const FootballTeamPicker = () => {
     const handleGenerateSummary = async (setupIndex: number) => {
         if (!geminiKey) return;
         const setup = teamSetups[setupIndex];
-        const prompt = `Write a colourful, fun, and slightly cheeky pre-match hype summary for this football game (the match has not been played yet). Mention the teams, their names, and comment on the players and their roles. Be creative and playful, add some relevant emojis, and keep it under 100 words. Format your response in markdown.` +
-            `\n\n${setup.teams.map((team: any, idx: number) => `Team ${idx + 1} (${team.name}):\n` + team.players.map((p: any) => `- ${p.name} (${p.role})`).join('\n')).join('\n\n')}`;
+        const toneInstruction = warrenMode
+            ? ` Use a ${Math.random() < warrenAggression / 100 ? 'grumpy and angry' : 'cheerful and encouraging'} tone.`
+            : '';
+        const prompt =
+            `Write a colourful, fun, and slightly cheeky pre-match hype summary for this football game (the match has not been played yet). Mention the teams, their names, and comment on the players and their roles. Be creative and playful, add some relevant emojis, and keep it under 100 words. Format your response in markdown.` +
+            toneInstruction +
+            `\n\n${setup.teams
+                .map(
+                    (team: any, idx: number) =>
+                        `Team ${idx + 1} (${team.name}):\n` +
+                        team.players.map((p: any) => `- ${p.name} (${p.role})`).join('\n')
+                )
+                .join('\n\n')}`;
         setAISummaries(prev => ({ ...prev, [setupIndex]: 'Loading...' }));
         try {
             const res = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${aiModel}:generateContent?key=` + geminiKey, {


### PR DESCRIPTION
## Summary
- include a Warren tone instruction in the AI summary prompt so the AI is either happy or angry when Warren Mode is enabled

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68795aeaadcc83339d57e2a700f3bb6f