### PR TITLE
Fix Warren summary tone

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -584,9 +584,9 @@ const FootballTeamPicker = () => {
             });
             const data = await res.json();
             const summary = data.candidates?.[0]?.content?.parts?.[0]?.text || 'No summary generated.';
-            setAISummaries(prev => ({ ...prev, [setupIndex]: applyWarrenTone(summary) }));
+            setAISummaries(prev => ({ ...prev, [setupIndex]: summary }));
         } catch {
-            setAISummaries(prev => ({ ...prev, [setupIndex]: applyWarrenTone('Error generating summary.') }));
+            setAISummaries(prev => ({ ...prev, [setupIndex]: 'Error generating summary.' }));
         }
     };
 


### PR DESCRIPTION
## Summary
- remove extra phrases from Warren AI summary

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687a0c71782c8333bb87c62b1da6e127