### PR TITLE
Update team suffixes

### DIFF
--- a/src/constants/teamConstants.ts
+++ b/src/constants/teamConstants.ts
@@ -116,5 +116,10 @@ export const teamSuffixes = [
     "Dynamoes", "Comets", "Blazers", "Chargers", "Hurricanes",
     "Vikings", "Eagles", "Lions", "Sharks", "Panthers",
     "FC", "Albion", "Hotshots", "Unathletic", "Spanners",
-    "Plumbers", "Pirates"
+    "Plumbers", "Pirates",
+    "Bulldogs", "Dragons", "Stallions", "Thunder", "Storm",
+    "Lightning", "Bears", "Hornets", "Hawks", "Knights",
+    "Raiders", "Giants", "Rockets", "Cheetahs", "Cyclones",
+    "Pythons", "Falcons", "Cougars", "Kings", "Royals",
+    "Senators", "Stars", "Tigers"
 ];


### PR DESCRIPTION
## Summary
- expand the list of team suffixes to 50 different options

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687a0d10a66883338c1fab8d624c4693