### PR TITLE
Fix unreachable return in location utility

### DIFF
--- a/src/utils/locationUtils.ts
+++ b/src/utils/locationUtils.ts
@@ -41,9 +41,6 @@ export const getPlacesBasedOnLocation = async (): Promise<{ location: string; pl
         }
 
         return { location: closestLocation, places: closestPlaces };
-
-        // Default to Generic places
-        return { location: 'Generic', places: teamPlaces.Generic.places };
     } catch (error) {
         console.error('Failed to get location:', error);
         return { location: 'Generic', places: teamPlaces.Generic.places }; // Default to Generic places if location fails


### PR DESCRIPTION
## Summary
- remove redundant return block from `getPlacesBasedOnLocation`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687aa76f181c8333b9daca468d95037e