### PR TITLE
Add install button for PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A React web app built to simplify picking 5-a-side football teams. The app ensur
 - Export saved teams as an image to share with friends
 - Optional "Warren Mode" spices up warnings and summaries. When enabled you can set an aggression slider (0-100%) to control how often the tone is nasty (defaults to 20%).
 - Installable PWA with offline support
+- Install button available in the configuration menu for quick installation
 
 ### Local Development
 


### PR DESCRIPTION
## Summary
- allow installing the app directly from the configuration dialog
- mention the install button in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687ac79341a0833397cd8ddc0eec94af