### PR TITLE
Add basic WebXR lineup display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.0.2",
+        "@types/three": "^0.178.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "d3": "^7.9.0",
@@ -19,7 +20,8 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
         "tailwind-merge": "^2.2.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "three": "^0.178.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -351,6 +353,12 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -1374,6 +1382,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1494,10 +1508,37 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.178.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.1.tgz",
+      "integrity": "sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1732,6 +1773,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -2999,6 +3046,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3824,6 +3877,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -5271,6 +5330,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6068,6 +6133,11 @@
         }
       }
     },
+    "@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -6637,6 +6707,11 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true
     },
+    "@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="
+    },
     "@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -6750,10 +6825,34 @@
       "dev": true,
       "requires": {}
     },
+    "@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="
+    },
+    "@types/three": {
+      "version": "0.178.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.1.tgz",
+      "integrity": "sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==",
+      "requires": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
     "@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.27.0",
@@ -6894,6 +6993,11 @@
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.14.2"
       }
+    },
+    "@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A=="
     },
     "acorn": {
       "version": "8.14.1",
@@ -7739,6 +7843,11 @@
         "reusify": "^1.0.4"
       }
     },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8303,6 +8412,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="
     },
     "micromark": {
       "version": "4.0.2",
@@ -9169,6 +9283,11 @@
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
+    },
+    "three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
+    "@types/three": "^0.178.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "d3": "^7.9.0",
@@ -23,7 +24,8 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
     "tailwind-merge": "^2.2.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "three": "^0.178.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,25 +13,11 @@ import FloatingFooter from './components/FloatingFooter';
 import HeaderBar from './components/HeaderBar';
 import { teamPlaces } from './constants/teamConstants';
 import { positionsByTeamSizeAndSide, placeholderPositions } from './constants/positionsConstants';
+import type { Player, Team } from './types';
+import ARLineup from './components/ARLineup';
 import ReactMarkdown from 'react-markdown';
 import { pickSecondColor } from './utils/colorUtils';
 
-interface Player {
-    name: string;
-    isGoalkeeper: boolean;
-    isStriker: boolean;
-    isDefender: boolean;
-    isteam1: boolean;
-    isteam2: boolean;
-    role: string;
-    shirtNumber: number | null;
-}
-
-interface Team {
-    name: string;
-    players: Player[];
-    color: string;
-}
 
 interface TeamSetup {
     teams: Team[];
@@ -50,6 +36,7 @@ const FootballTeamPicker = () => {
         return localStorage.getItem('playersText') || '';
     });
     const [teamSetups, setTeamSetups] = useState<TeamSetup[]>([]);
+    const [arSetupIndex, setARSetupIndex] = useState<number | null>(null);
     const [errorMessage, setErrorMessage] = useState('');
     const [playerNumbers, setPlayerNumbers] = useState<{ [playerName: string]: number }>({});
     const [selectedLocation, setSelectedLocation] = useState(() => {
@@ -963,6 +950,12 @@ Billy #g"
                                                         {aiSummaries[setupIndex] === 'Loading...' ? 'Generating...' : 'Generate AI Match Summary'}
                                                     </Button>
                                                 )}
+                                                <Button
+                                                    onClick={() => setARSetupIndex(setupIndex)}
+                                                    className="bg-blue-600 text-white font-bold px-3 py-1 rounded shadow ml-2"
+                                                >
+                                                    View in AR
+                                                </Button>
                                             </div>
                                         )}
                                         {aiSummaries[setupIndex] && (
@@ -986,6 +979,12 @@ Billy #g"
                 onShare={shareAllImages}
                 teamCount={teamSetups.length}
             />
+            {arSetupIndex !== null && teamSetups[arSetupIndex] && (
+                <ARLineup
+                    teams={teamSetups[arSetupIndex].teams}
+                    onClose={() => setARSetupIndex(null)}
+                />
+            )}
         </div>
     );
 };

--- a/src/components/ARLineup.tsx
+++ b/src/components/ARLineup.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { ARButton } from 'three/examples/jsm/webxr/ARButton.js';
+import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
+import { createRoot } from 'react-dom/client';
+import PlayerIcon from './PlayerIcon';
+import { positionsByTeamSizeAndSide } from '../constants/positionsConstants';
+import type { Player, Team } from '../types';
+
+interface ARLineupProps {
+    teams: Team[];
+    onClose: () => void;
+}
+
+const convertToWorld = (top: string, left: string, width = 2, height = 1) => {
+    const x = (parseFloat(left) / 100 - 0.5) * width;
+    const z = (0.5 - parseFloat(top) / 100) * height;
+    return { x, z };
+};
+
+const ARLineup: React.FC<ARLineupProps> = ({ teams, onClose }) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera();
+        const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.xr.enabled = true;
+        container.appendChild(renderer.domElement);
+        container.appendChild(ARButton.createButton(renderer));
+
+        const labelRenderer = new CSS2DRenderer();
+        labelRenderer.setSize(window.innerWidth, window.innerHeight);
+        labelRenderer.domElement.style.position = 'absolute';
+        labelRenderer.domElement.style.top = '0';
+        container.appendChild(labelRenderer.domElement);
+
+        const fieldGroup = new THREE.Group();
+        fieldGroup.position.set(0, -0.5, -2);
+        scene.add(fieldGroup);
+
+        teams.slice(0, 2).forEach((team, idx) => {
+            const side = idx === 0 ? 'left' : 'right';
+            const positions =
+                positionsByTeamSizeAndSide[team.players.length]?.[side] || [];
+            team.players.forEach((player: Player, pIdx: number) => {
+                const slot = positions[pIdx];
+                if (!slot) return;
+                const { x, z } = convertToWorld(slot.top, slot.left);
+                const div = document.createElement('div');
+                div.style.width = '64px';
+                div.style.height = '64px';
+                const root = createRoot(div);
+                root.render(
+                    <PlayerIcon
+                        color={team.color}
+                        number={player.shirtNumber}
+                        name={player.name}
+                        isGoalkeeper={player.isGoalkeeper}
+                    />
+                );
+                const obj = new CSS2DObject(div);
+                obj.position.set(x, 0, z);
+                fieldGroup.add(obj);
+            });
+        });
+
+        const renderScene = () => {
+            renderer.render(scene, camera);
+            labelRenderer.render(scene, camera);
+        };
+
+        renderer.setAnimationLoop(renderScene);
+
+        return () => {
+            renderer.setAnimationLoop(null);
+            container.innerHTML = '';
+        };
+    }, [teams]);
+
+    return (
+        <div ref={containerRef} className="fixed inset-0 z-50">
+            <button
+                className="absolute top-2 right-2 bg-white text-black px-3 py-1 rounded"
+                onClick={onClose}
+            >
+                Close AR
+            </button>
+        </div>
+    );
+};
+
+export default ARLineup;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export interface Player {
+    name: string;
+    isGoalkeeper: boolean;
+    isStriker: boolean;
+    isDefender: boolean;
+    isteam1: boolean;
+    isteam2: boolean;
+    role: string;
+    shirtNumber: number | null;
+}
+
+export interface Team {
+    name: string;
+    players: Player[];
+    color: string;
+}


### PR DESCRIPTION
## Summary
- add ARLineup component using three.js to render players in AR
- export Player and Team interfaces for reuse
- hook AR button into app and show players using WebXR
- install three and @types/three

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ad1520ba88333aebbbf3bf9a5a9c0