### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ const FootballTeamPicker = () => {
         const stored = localStorage.getItem('warrenAggression');
         return stored ? Number(stored) : 20;
     });
+    const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
     const aiInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
@@ -90,6 +91,11 @@ const FootballTeamPicker = () => {
     useEffect(() => {
         localStorage.setItem('warrenAggression', String(warrenAggression));
     }, [warrenAggression]);
+
+    useEffect(() => {
+        document.documentElement.classList.toggle('dark', darkMode);
+        localStorage.setItem('darkMode', String(darkMode));
+    }, [darkMode]);
 
     useEffect(() => {
         // Update places based on selected location
@@ -611,6 +617,8 @@ const FootballTeamPicker = () => {
                 onWarrenModeChange={setWarrenMode}
                 warrenAggression={warrenAggression}
                 onWarrenAggressionChange={setWarrenAggression}
+                darkMode={darkMode}
+                onDarkModeChange={setDarkMode}
             />
             <div className="flex-grow p-4 sm:p-6">
                 {/* Notifications */}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -22,6 +22,8 @@ interface HeaderBarProps {
     onWarrenModeChange: (value: boolean) => void;
     warrenAggression: number;
     onWarrenAggressionChange: (value: number) => void;
+    darkMode: boolean;
+    onDarkModeChange: (value: boolean) => void;
 }
 
 const HeaderBar: React.FC<HeaderBarProps> = ({
@@ -39,6 +41,8 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     onWarrenModeChange,
     warrenAggression,
     onWarrenAggressionChange,
+    darkMode,
+    onDarkModeChange,
 }) => {
     const [showConfig, setShowConfig] = useState(false);
     const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
@@ -175,6 +179,17 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                                     />
                                 </div>
                             )}
+                        </div>
+                        <div>
+                            <label className="font-bold flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    checked={darkMode}
+                                    onChange={(e) => onDarkModeChange(e.target.checked)}
+                                />
+                                Dark Mode
+                            </label>
+                            <p className="text-xs mt-1">Switches between light and dark themes.</p>
                         </div>
                         {!isStandalone && installPrompt && (
                             <div>


### PR DESCRIPTION
## Summary
- enable dark mode support at the app level
- add toggle in header settings panel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687ac7f39fc88333a3da44378b67e681