### PR TITLE
Add settings modal overlay

### DIFF
--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
-import { Settings, Info, X } from 'lucide-react';
+import { Settings, Info, Bot, Check, X } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -56,6 +56,21 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                 >
                     <Settings className="w-5 h-5" />
                 </Button>
+                <button
+                    onClick={() => {
+                        setShowConfig(true);
+                        setTimeout(() => aiInputRef.current?.focus(), 0);
+                    }}
+                    className="ml-2 relative text-white"
+                    aria-label="AI status"
+                >
+                    <Bot className="w-5 h-5" />
+                    {aiEnabled ? (
+                        <Check className="absolute -right-1 -bottom-1 w-3 h-3 bg-green-700 text-white rounded-full" />
+                    ) : (
+                        <X className="absolute -right-1 -bottom-1 w-3 h-3 bg-red-700 text-white rounded-full" />
+                    )}
+                </button>
                 {aiEnabled && (
                     <button
                         onClick={() => {

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
-import { Settings, Info, Bot, Check, X } from 'lucide-react';
+import { Settings, Bot, Check, X } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -71,18 +71,6 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                         <X className="absolute -right-1 -bottom-1 w-3 h-3 bg-red-700 text-white rounded-full" />
                     )}
                 </button>
-                {aiEnabled && (
-                    <button
-                        onClick={() => {
-                            setShowConfig(true);
-                            setTimeout(() => aiInputRef.current?.focus(), 0);
-                        }}
-                        className="ml-2 text-white"
-                        aria-label="Gemini settings"
-                    >
-                        <Info className="w-4 h-4" />
-                    </button>
-                )}
             </div>
             {showConfig && (
                 <div

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
-import { Settings, Info, X } from 'lucide-react';
+import { Settings, Bot, Check, X } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -50,12 +50,20 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
             <div className="relative flex items-center">
                 <Button
                     onClick={() => setShowConfig(true)}
-                    className="p-2 rounded-full bg-blue-700 dark:bg-blue-600 text-white shadow"
+                    variant="ghost"
                     size="icon"
+                    className="rounded-full text-white"
                 >
                     <Settings className="w-5 h-5" />
                 </Button>
-                {aiEnabled && <Info className="w-4 h-4 text-yellow-300 ml-1" />}
+                <div className="relative ml-2">
+                    <Bot className="w-4 h-4 text-white" />
+                    {aiEnabled ? (
+                        <Check className="absolute -bottom-1 -right-1 w-3 h-3 text-white" />
+                    ) : (
+                        <X className="absolute -bottom-1 -right-1 w-3 h-3 text-white" />
+                    )}
+                </div>
             </div>
             {showConfig && (
                 <div className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-30">

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
-import { Settings, Bot, Check, X } from 'lucide-react';
+import { Settings, Info, X } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -56,18 +56,28 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                 >
                     <Settings className="w-5 h-5" />
                 </Button>
-                <div className="relative ml-2">
-                    <Bot className="w-4 h-4 text-white" />
-                    {aiEnabled ? (
-                        <Check className="absolute -bottom-1 -right-1 w-3 h-3 text-white" />
-                    ) : (
-                        <X className="absolute -bottom-1 -right-1 w-3 h-3 text-white" />
-                    )}
-                </div>
+                {aiEnabled && (
+                    <button
+                        onClick={() => {
+                            setShowConfig(true);
+                            setTimeout(() => aiInputRef.current?.focus(), 0);
+                        }}
+                        className="ml-2 text-white"
+                        aria-label="Gemini settings"
+                    >
+                        <Info className="w-4 h-4" />
+                    </button>
+                )}
             </div>
             {showConfig && (
-                <div className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-30">
-                    <div className="relative w-80 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg p-4 text-green-900 dark:text-green-100 space-y-4">
+                <div
+                    className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-30"
+                    onClick={() => setShowConfig(false)}
+                >
+                    <div
+                        className="relative w-80 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg p-4 text-green-900 dark:text-green-100 space-y-4"
+                        onClick={(e) => e.stopPropagation()}
+                    >
                         <button
                             onClick={() => setShowConfig(false)}
                             className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 dark:text-gray-300"

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
+import { Settings, Info, X } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -42,17 +43,29 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
 }) => {
     const [showConfig, setShowConfig] = useState(false);
 
+    const aiEnabled = Boolean(geminiKey);
+
     return (
         <header className="bg-green-900 text-white p-4 flex justify-end relative z-10 dark:bg-green-950">
-            <div className="relative">
+            <div className="relative flex items-center">
                 <Button
-                    onClick={() => setShowConfig(v => !v)}
-                    className="bg-blue-700 dark:bg-blue-600 text-white font-bold px-3 py-1 rounded shadow"
+                    onClick={() => setShowConfig(true)}
+                    className="p-2 rounded-full bg-blue-700 dark:bg-blue-600 text-white shadow"
+                    size="icon"
                 >
-                    Configuration
+                    <Settings className="w-5 h-5" />
                 </Button>
-                {showConfig && (
-                    <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg p-4 z-30 text-green-900 dark:text-green-100 space-y-4">
+                {aiEnabled && <Info className="w-4 h-4 text-yellow-300 ml-1" />}
+            </div>
+            {showConfig && (
+                <div className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-30">
+                    <div className="relative w-80 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg p-4 text-green-900 dark:text-green-100 space-y-4">
+                        <button
+                            onClick={() => setShowConfig(false)}
+                            className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 dark:text-gray-300"
+                        >
+                            <X className="w-4 h-4" />
+                        </button>
                         <div>
                             <div className="font-bold mb-1">Locale</div>
                             <p className="text-xs mb-2">Used for team name suggestions.</p>
@@ -166,8 +179,8 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                             <p className="text-xs mt-1">Switches between light and dark themes.</p>
                         </div>
                     </div>
-                )}
-            </div>
+                </div>
+            )}
         </header>
     );
 };


### PR DESCRIPTION
## Summary
- convert header config drop-down into a modal overlay
- use a gear icon for the settings button
- indicate AI key presence with an info icon

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687b91322aa483338321d9cd2a40ba75