### PR TITLE
Move title to header with info modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -631,17 +631,7 @@ const FootballTeamPicker = () => {
                 )}
 
                 {/* Title Section */}
-                <div className="text-center space-y-3 mb-6">
-                    <div className="flex justify-center items-center gap-3">
-                        <img
-                            src="/logo.png" // Path to the logo in the public folder
-                            alt="Team Shuffle Logo"
-                            className="w-12 h-12 sm:w-16 sm:h-16"
-                        />
-                        <h1 className="text-4xl sm:text-5xl font-extrabold text-white tracking-tight drop-shadow-lg">
-                            Team Shuffle
-                        </h1>
-                    </div>
+                <div className="text-center space-y-3 mb-6 mt-4">
                     <p className="text-gray-200 text-lg sm:text-xl">
                         Pick your 5-a-side football teams<br />
                         <span className="text-yellow-300 text-base sm:text-lg font-semibold block mt-2">

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
-import { Settings, Bot, Check, X, Info } from 'lucide-react';
+import { Settings, Bot, Check, X } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -42,7 +42,6 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     onDarkModeChange,
 }) => {
     const [showConfig, setShowConfig] = useState(false);
-    const [showInfo, setShowInfo] = useState(false);
 
     const aiEnabled = Boolean(geminiKey);
 
@@ -53,15 +52,6 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                 <span className="font-bold text-xl">Team Shuffle</span>
             </div>
             <div className="relative flex items-center gap-2">
-                <Button
-                    onClick={() => setShowInfo(true)}
-                    variant="ghost"
-                    size="icon"
-                    className="rounded-full text-white"
-                    aria-label="App info"
-                >
-                    <Info className="w-5 h-5" />
-                </Button>
                 <Button
                     onClick={() => setShowConfig(true)}
                     variant="ghost"
@@ -213,31 +203,6 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                             </label>
                             <p className="text-xs mt-1">Switches between light and dark themes.</p>
                         </div>
-                    </div>
-                </div>
-            )}
-            {showInfo && (
-                <div
-                    className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-30"
-                    onClick={() => setShowInfo(false)}
-                >
-                    <div
-                        className="relative w-80 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg p-4 text-green-900 dark:text-green-100 space-y-2"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <button
-                            onClick={() => setShowInfo(false)}
-                            className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 dark:text-gray-300"
-                        >
-                            <X className="w-4 h-4" />
-                        </button>
-                        <h2 className="text-lg font-bold mb-2">About Team Shuffle</h2>
-                        <ul className="list-disc pl-5 text-sm space-y-1">
-                            <li>Balance teams by tagging keepers, defenders and strikers.</li>
-                            <li>Generate fun team names based on location.</li>
-                            <li>Use AI to create match summaries.</li>
-                            <li>Export or share your line-ups.</li>
-                        </ul>
                     </div>
                 </div>
             )}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
 import { teamPlaces } from '../constants/teamConstants';
-import { Settings, Bot, Check, X } from 'lucide-react';
+import { Settings, Bot, Check, X, Info } from 'lucide-react';
 
 
 interface HeaderBarProps {
@@ -42,12 +42,26 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     onDarkModeChange,
 }) => {
     const [showConfig, setShowConfig] = useState(false);
+    const [showInfo, setShowInfo] = useState(false);
 
     const aiEnabled = Boolean(geminiKey);
 
     return (
-        <header className="bg-green-900 text-white p-4 flex justify-end relative z-10 dark:bg-green-950">
-            <div className="relative flex items-center">
+        <header className="bg-green-900 text-white p-4 flex items-center justify-between relative z-10 dark:bg-green-950">
+            <div className="flex items-center gap-2">
+                <img src="/logo.png" alt="Team Shuffle Logo" className="w-8 h-8" />
+                <span className="font-bold text-xl">Team Shuffle</span>
+            </div>
+            <div className="relative flex items-center gap-2">
+                <Button
+                    onClick={() => setShowInfo(true)}
+                    variant="ghost"
+                    size="icon"
+                    className="rounded-full text-white"
+                    aria-label="App info"
+                >
+                    <Info className="w-5 h-5" />
+                </Button>
                 <Button
                     onClick={() => setShowConfig(true)}
                     variant="ghost"
@@ -61,7 +75,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                         setShowConfig(true);
                         setTimeout(() => aiInputRef.current?.focus(), 0);
                     }}
-                    className="ml-2 relative text-white"
+                    className="relative text-white"
                     aria-label="AI status"
                 >
                     <Bot className="w-5 h-5" />
@@ -199,6 +213,31 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                             </label>
                             <p className="text-xs mt-1">Switches between light and dark themes.</p>
                         </div>
+                    </div>
+                </div>
+            )}
+            {showInfo && (
+                <div
+                    className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-30"
+                    onClick={() => setShowInfo(false)}
+                >
+                    <div
+                        className="relative w-80 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg p-4 text-green-900 dark:text-green-100 space-y-2"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <button
+                            onClick={() => setShowInfo(false)}
+                            className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 dark:text-gray-300"
+                        >
+                            <X className="w-4 h-4" />
+                        </button>
+                        <h2 className="text-lg font-bold mb-2">About Team Shuffle</h2>
+                        <ul className="list-disc pl-5 text-sm space-y-1">
+                            <li>Balance teams by tagging keepers, defenders and strikers.</li>
+                            <li>Generate fun team names based on location.</li>
+                            <li>Use AI to create match summaries.</li>
+                            <li>Export or share your line-ups.</li>
+                        </ul>
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary
- move the Team Shuffle logo and title into the header bar
- add an info button and modal explaining app features
- keep the tagline below the header

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687b9f9c6d608333b9ee127a30a8d266