### PR TITLE
Enable dark mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A React web app built to simplify picking 5-a-side football teams. The app ensur
 - Randomly generated team names, with local options for London and Hampshire (more regions can be added)
 - Export saved teams as an image to share with friends
 - Optional "Warren Mode" spices up warnings and summaries. When enabled you can set an aggression slider (0-100%) to control how often the tone is nasty (defaults to 20%).
-- Toggleable dark mode for late-night team planning
+- Dark mode enabled by default with option to switch to light theme
 
 ### Local Development
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
 </head>
 
 <body>
+  <script>
+    const stored = localStorage.getItem('darkMode');
+    if (!stored || stored === 'true') {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
 </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,10 @@ const FootballTeamPicker = () => {
         const stored = localStorage.getItem('warrenAggression');
         return stored ? Number(stored) : 20;
     });
-    const [darkMode, setDarkMode] = useState(() => localStorage.getItem('darkMode') === 'true');
+    const [darkMode, setDarkMode] = useState(() => {
+        const stored = localStorage.getItem('darkMode');
+        return stored ? stored === 'true' : true;
+    });
     const aiInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- default to dark mode if no preference is stored
- add early script to apply dark theme before React loads
- document the default dark mode behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687c07e546b08333a0dcb1c5ad3c8fed