### PR TITLE
feat: allow custom AI instructions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,9 @@ const FootballTeamPicker = () => {
     } | null>(null);
     const [geminiKey, setGeminiKey] = useState(() => localStorage.getItem('geminiKey') || '');
     const [aiModel, setAIModel] = useState(() => localStorage.getItem('aiModel') || 'gemini-2.0-flash');
+    const [aiCustomInstructions, setAICustomInstructions] = useState(() =>
+        localStorage.getItem('aiCustomInstructions') || ''
+    );
     const [aiSummaries, setAISummaries] = useState<{ [setupIndex: number]: string }>({});
     const [geminiKeyError, setGeminiKeyError] = useState<string | null>(null);
     const [warrenMode, setWarrenMode] = useState(() => localStorage.getItem('warrenMode') === 'true');
@@ -100,6 +103,10 @@ const FootballTeamPicker = () => {
         document.documentElement.classList.toggle('dark', darkMode);
         localStorage.setItem('darkMode', String(darkMode));
     }, [darkMode]);
+
+    useEffect(() => {
+        localStorage.setItem('aiCustomInstructions', aiCustomInstructions);
+    }, [aiCustomInstructions]);
 
     useEffect(() => {
         if (navigator.permissions?.query) {
@@ -592,9 +599,11 @@ const FootballTeamPicker = () => {
         const toneInstruction = warrenMode
             ? ` Use a ${Math.random() < warrenAggression / 100 ? 'grumpy and angry' : 'cheerful and encouraging'} tone.`
             : '';
+        const customInstruction = aiCustomInstructions ? ` ${aiCustomInstructions}` : '';
         const prompt =
             `Write a colourful, fun, and slightly cheeky pre-match hype summary for this football game (the match has not been played yet). Mention the teams, their names, and comment on the players and their roles. Be creative and playful, add some relevant emojis, and keep it under 100 words. Format your response in markdown.` +
             toneInstruction +
+            customInstruction +
             `\n\n${setup.teams
                 .map(
                     (team: Team, idx: number) =>
@@ -639,6 +648,8 @@ const FootballTeamPicker = () => {
                 onGeminiKeySave={handleGeminiKeySave}
                 aiInputRef={aiInputRef}
                 geminiKeyError={geminiKeyError}
+                aiCustomInstructions={aiCustomInstructions}
+                onCustomInstructionsChange={setAICustomInstructions}
                 warrenMode={warrenMode}
                 onWarrenModeChange={setWarrenMode}
                 warrenAggression={warrenAggression}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -17,6 +17,8 @@ interface HeaderBarProps {
     onGeminiKeySave: () => void;
     aiInputRef: React.RefObject<HTMLInputElement>;
     geminiKeyError: string | null;
+    aiCustomInstructions: string;
+    onCustomInstructionsChange: (value: string) => void;
     warrenMode: boolean;
     onWarrenModeChange: (value: boolean) => void;
     warrenAggression: number;
@@ -38,6 +40,8 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     onGeminiKeySave,
     aiInputRef,
     geminiKeyError,
+    aiCustomInstructions,
+    onCustomInstructionsChange,
     warrenMode,
     onWarrenModeChange,
     warrenAggression,
@@ -181,6 +185,13 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                             {geminiKeyError && (
                                 <div className="text-red-600 text-sm mt-2">{geminiKeyError}</div>
                             )}
+                            <label className="block font-semibold mb-1">Custom Instructions</label>
+                            <textarea
+                                value={aiCustomInstructions}
+                                onChange={(e) => onCustomInstructionsChange(e.target.value)}
+                                className="w-full h-24 border p-2 rounded mb-2 dark:bg-gray-700 dark:text-white"
+                                placeholder="Any extra instructions for the AI"
+                            />
                         </div>
                         <div>
                             <label className="font-bold flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add text area in settings for custom AI match summary instructions
- store and persist custom AI instructions and include them in the summary prompt

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68930cb4aa9483338353972d1385b57f