### PR TITLE
feat: suggest advanced features after repeated use

### DIFF
--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -25,6 +25,8 @@ interface HeaderBarProps {
     onWarrenAggressionChange: (value: number) => void;
     darkMode: boolean;
     onDarkModeChange: (value: boolean) => void;
+    teamsGenerated: number;
+    teamsExported: number;
 }
 
 const HeaderBar: React.FC<HeaderBarProps> = ({
@@ -48,6 +50,8 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
     onWarrenAggressionChange,
     darkMode,
     onDarkModeChange,
+    teamsGenerated,
+    teamsExported,
 }) => {
     const [showConfig, setShowConfig] = useState(false);
 
@@ -229,6 +233,12 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                                 Dark Mode
                             </label>
                             <p className="text-xs mt-1">Switches between light and dark themes.</p>
+                        </div>
+                        <div>
+                            <div className="font-bold mb-1">Usage</div>
+                            <p className="text-xs mb-2">Stored locally on this browser.</p>
+                            <div className="text-sm">Teams generated: {teamsGenerated}</div>
+                            <div className="text-sm">Teams exported: {teamsExported}</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- track app launches in localStorage and remind users after 5 visits if AI and location features remain unused
- record when AI summaries are generated and when location lookup runs to avoid repeated reminders
- display usage stats (teams generated and exported) in settings, persisting counts to localStorage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c68d7b0a108333934aa66488f1235e